### PR TITLE
adding range of ports for apps to escape

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ VOLUME    ["/www"]
 WORKDIR   /www
 
 # Open ports
-EXPOSE    3030
+EXPOSE    3030-4030
 EXPOSE    5858
 EXPOSE    8080
 


### PR DESCRIPTION
if we're using Docker > 1.5 this should work.  It'll let multiple apps exist at the same time (eg localhost:3031 and localhost:3032) and keep the ports consistent across dev and prod. I picked 4030 "because"
